### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/COVID19-mesa-master/.github/workflows/ci.yaml
+++ b/COVID19-mesa-master/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       id: extract_tag_name
 
     - name: Build Covid19-Mesa Image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ncsa/covid19-mesa:${{ steps.extract_tag_name.outputs.imagetag }}
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore